### PR TITLE
Fixed incorrect characters

### DIFF
--- a/exercises/3_4_Sit-Up/exercise.json
+++ b/exercises/3_4_Sit-Up/exercise.json
@@ -10,7 +10,7 @@
     "Lie down on the floor and secure your feet. Your legs should be bent at the knees.",
     "Place your hands behind or to the side of your head. You will begin with your back on the ground. This will be your starting position.",
     "Flex your hips and spine to raise your torso toward your knees.",
-    "At the top of the contraction your torso should be perpendicular to the ground. Reverse the motion, going only Â¾ of the way down.",
+    "At the top of the contraction your torso should be perpendicular to the ground. Reverse the motion, going only ¾ of the way down.",
     "Repeat for the recommended amount of repetitions."
   ],
   "category": "strength"

--- a/exercises/Butt-Ups/exercise.json
+++ b/exercises/Butt-Ups/exercise.json
@@ -11,7 +11,7 @@
   "instructions": [
     "Begin a pushup position but with your elbows on the ground and resting on your forearms. Your arms should be bent at a 90 degree angle.",
     "Arch your back slightly out rather than keeping your back completely straight.",
-    "Raise your glutes toward the ceiling, squeezing your abs tightly to close the distance between your ribcage and hips. The end result will be that youâ€™ll end up in a high bridge position. Exhale as you perform this portion of the movement.",
+    "Raise your glutes toward the ceiling, squeezing your abs tightly to close the distance between your ribcage and hips. The end result will be that you'll end up in a high bridge position. Exhale as you perform this portion of the movement.",
     "Lower back down slowly to your starting position as you breathe in. Tip: Don't let your back sag downwards.",
     "Repeat for the recommended amount of repetitions."
   ],

--- a/exercises/Cable_Internal_Rotation/exercise.json
+++ b/exercises/Cable_Internal_Rotation/exercise.json
@@ -9,8 +9,8 @@
   ],
   "secondaryMuscles": [],
   "instructions": [
-    "Sit next to a low pulley sideways (with legs stretched in front of you or crossed) and grasp the single hand cable attachment with the arm nearest to the cable. Tip: If you can adjust the pulleyâ€™s height, you can use a flat bench to sit on instead.",
-    "Position the elbow against your side with the elbow bent at 90Â° and the arm pointing towards the pulley. This will be your starting position.",
+    "Sit next to a low pulley sideways (with legs stretched in front of you or crossed) and grasp the single hand cable attachment with the arm nearest to the cable. Tip: If you can adjust the pulley's height, you can use a flat bench to sit on instead.",
+    "Position the elbow against your side with the elbow bent at 90° and the arm pointing towards the pulley. This will be your starting position.",
     "Pull the single hand cable attachment toward your body by internally rotating your shoulder until your forearm is across your abs. You will be creating an imaginary semi-circle. Tip: The forearm should be perpendicular to your torso at all times.",
     "Slowly go back to the initial position.",
     "Repeat for the recommended amount of repetitions and then repeat the movement with the next arm."

--- a/exercises/Cable_Iron_Cross/exercise.json
+++ b/exercises/Cable_Iron_Cross/exercise.json
@@ -8,7 +8,7 @@
   "secondaryMuscles": [],
   "instructions": [
     "Begin by moving the pulleys to the high position, select the resistance to be used, and take a handle in each hand.",
-    "Stand directly between both pulleys with your arms extended out to your sides. Your head and chest should be up while your arms form a â€œTâ€. This will be your starting position.",
+    "Stand directly between both pulleys with your arms extended out to your sides. Your head and chest should be up while your arms form a \"T\". This will be your starting position.",
     "Keeping the elbows extended, pull your arms straight to your sides.",
     "Return your arms back to the starting position after a pause at the peak contraction.",
     "Continue the movement for the prescribed number of repetitions."

--- a/exercises/Cable_Judo_Flip/exercise.json
+++ b/exercises/Cable_Judo_Flip/exercise.json
@@ -8,7 +8,7 @@
   "secondaryMuscles": [],
   "instructions": [
     "Connect a rope attachment to a tower, and move the cable to the lowest pulley position. Stand with your side to the cable with a wide stance, and grab the rope with both hands.",
-    "Twist your body away from the pulley as you bring the rope over your shoulder like youâ€™re performing a judo flip.",
+    "Twist your body away from the pulley as you bring the rope over your shoulder like you're performing a judo flip.",
     "Shift your weight between your feet as you twist and crunch forward, pulling the cable downward.",
     "Return to the starting position and repeat until failure.",
     "Then, reposition and repeat the same series of movements on the opposite side."

--- a/exercises/Cable_Russian_Twists/exercise.json
+++ b/exercises/Cable_Russian_Twists/exercise.json
@@ -10,7 +10,7 @@
   "secondaryMuscles": [],
   "instructions": [
     "Connect a standard handle attachment, and position the cable to a middle pulley position.",
-    "Lie on a stability ball perpendicular to the cable and grab the handle with one hand. You should be approximately armâ€™s length away from the pulley, with the tension of the weight on the cable.",
+    "Lie on a stability ball perpendicular to the cable and grab the handle with one hand. You should be approximately arm's length away from the pulley, with the tension of the weight on the cable.",
     "Grab the handle with both hands and fully extend your arms above your chest. You hands should be directly in-line with the pulley. If not, adjust the pulley up or down until they are.",
     "Keep your hips elevated and abs engaged. Rotate your torso away from the pulley for a full-quarter rotation. Your body should be flat from head to knees.",
     "Pause for a moment and in a slow and controlled manner reset to the starting position. You should still have side tension on the cable in the resting position.",

--- a/exercises/Clock_Push-Up/exercise.json
+++ b/exercises/Clock_Push-Up/exercise.json
@@ -15,7 +15,7 @@
     "Move into a prone position on the floor, supporting your weight on your hands and toes.",
     "Your arms should be fully extended with the hands around shoulder width. Keep your body straight throughout the movement. This will be your starting position.",
     "Descend by flexing at the elbow, lowering your chest toward the ground.",
-    "At the bottom, reverse the motion by pushing yourself up through elbow extension as quickly as possible until you are air borne. Aim to â€œjumpâ€ 12-18 inches to one side.",
+    "At the bottom, reverse the motion by pushing yourself up through elbow extension as quickly as possible until you are air borne. Aim to \"jump\" 12-18 inches to one side.",
     "As you accelerate up, move your outside foot away from your direction of travel. Leaving the ground, shift your body about 30 degrees for the next repetition.",
     "Return to the starting position and repeat the exercise, working all the way around until you are back where you started."
   ],

--- a/exercises/Close-Grip_Dumbbell_Press/exercise.json
+++ b/exercises/Close-Grip_Dumbbell_Press/exercise.json
@@ -14,7 +14,7 @@
   "instructions": [
     "Place a dumbbell standing up on a flat bench.",
     "Ensuring that the dumbbell stays securely placed at the top of the bench, lie perpendicular to the bench with only your shoulders lying on the surface. Hips should be below the bench and your legs bent with your feet firmly on the floor.",
-    "Grasp the dumbbell with both hands and hold it straight over your chest at armâ€™s length. Both palms should be pressing against the underside of the sides of the dumbbell. This will be your starting position.",
+    "Grasp the dumbbell with both hands and hold it straight over your chest at arm's length. Both palms should be pressing against the underside of the sides of the dumbbell. This will be your starting position.",
     "Initiate the movement by lowering the dumbbell to your chest.",
     "Return to the starting position by extending the elbows."
   ],

--- a/exercises/Kneeling_Cable_Crunch_With_Alternating_Oblique_Twists/exercise.json
+++ b/exercises/Kneeling_Cable_Crunch_With_Alternating_Oblique_Twists/exercise.json
@@ -12,7 +12,7 @@
     "Position the rope behind your head with your hands by your ears.",
     "Keep your hands in the same place, contract your abs and pull downward on the rope in a crunching movement until your elbows reach your knees.",
     "Pause briefly at the bottom and rise up in a slow and controlled manner until you reach the starting position.",
-    "Repeat the same downward movement until youâ€™re halfway down, at which time youâ€™ll begin rotating one of your elbows to the opposite knee.",
+    "Repeat the same downward movement until you're halfway down, at which time you'll begin rotating one of your elbows to the opposite knee.",
     "Again, pause briefly at the bottom and rise up in a slow and controlled manner until you reach the starting position.",
     "Repeat the same movement as before, but alternate the other elbow to the opposite knee.",
     "Continue this series of movements to failure."

--- a/exercises/One-Arm_Side_Laterals/exercise.json
+++ b/exercises/One-Arm_Side_Laterals/exercise.json
@@ -10,7 +10,7 @@
   "secondaryMuscles": [],
   "instructions": [
     "Pick a dumbbell and place it in one of your hands. Your non lifting hand should be used to grab something steady such as an incline bench press. Lean towards your lifting arm and away from the hand that is gripping the incline bench as this will allow you to keep your balance.",
-    "Stand with a straight torso and have the dumbbell by your side at armâ€™s length with the palm of the hand facing you. This will be your starting position.",
+    "Stand with a straight torso and have the dumbbell by your side at arm's length with the palm of the hand facing you. This will be your starting position.",
     "While maintaining the torso stationary (no swinging), lift the dumbbell to your side with a slight bend on the elbow and your hand slightly tilted forward as if pouring water in a glass. Continue to go up until you arm is parallel to the floor. Exhale as you execute this movement and pause for a second at the top.",
     "Lower the dumbbell back down slowly to the starting position as you inhale.",
     "Repeat for the recommended amount of repetitions.",

--- a/exercises/Pallof_Press/exercise.json
+++ b/exercises/Pallof_Press/exercise.json
@@ -7,8 +7,8 @@
   "primaryMuscles": ["abdominals"],
   "secondaryMuscles": ["chest", "shoulders", "triceps"],
   "instructions": [
-    "Connect a standard handle to a tower, andâ€”if possibleâ€”position the cable to shoulder height. If not, a low pulley will suffice.",
-    "With your side to the cable, grab the handle with both hands and step away from the tower. You should be approximately armâ€™s length away from the pulley, with the tension of the weight on the cable.",
+    "Connect a standard handle to a tower, and—if possible—position the cable to shoulder height. If not, a low pulley will suffice.",
+    "With your side to the cable, grab the handle with both hands and step away from the tower. You should be approximately arm's length away from the pulley, with the tension of the weight on the cable.",
     "With your feet positioned hip-width apart and knees slightly bent, hold the cable to the middle of your chest. This will be your starting position.",
     "Press the cable away from your chest, fully extending both arms. You core should be tight and engaged.",
     "Hold the repetition for several seconds before returning to the starting position.",

--- a/exercises/Pallof_Press_With_Rotation/exercise.json
+++ b/exercises/Pallof_Press_With_Rotation/exercise.json
@@ -14,7 +14,7 @@
   ],
   "instructions": [
     "Connect a standard handle to a tower, and position the cable to shoulder height.",
-    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately armâ€™s length away from the pulley, with the tension of the weight on the cable. Align outstretched arm with cable.",
+    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately arm's length away from the pulley, with the tension of the weight on the cable. Align outstretched arm with cable.",
     "With your feet positioned hip-width apart, pull the cable into your chest and grab the handle with your other hand. Both hands should be on the handle at this time.",
     "Facing forward, press the cable away from your chest. You core should be tight and engaged.",
     "Keeping your hips straight, twist your torso away from the pulley until you get a full quarter rotation.",

--- a/exercises/Romanian_Deadlift_from_Deficit/exercise.json
+++ b/exercises/Romanian_Deadlift_from_Deficit/exercise.json
@@ -14,7 +14,7 @@
     "traps"
   ],
   "instructions": [
-    "Begin standing while holding a bar at armâ€™s length in front of you. You can stand on a raised platform to increase the range of motion.",
+    "Begin standing while holding a bar at arm's length in front of you. You can stand on a raised platform to increase the range of motion.",
     "Begin by flexing the knees slightly, and then flex at the hip, moving your butt back as far as possible, lowering the torso as far as flexibility allows. The back should remain in absolute extension at all times, and the bar should remain in contact with the legs. If done properly, there should be heavy tension felt in the hamstrings.",
     "Reverse the motion to return to the starting position."
   ],

--- a/exercises/Skating/exercise.json
+++ b/exercises/Skating/exercise.json
@@ -14,7 +14,7 @@
   ],
   "instructions": [
     "Roller skating is a fun activity which can be effective in improving cardiorespiratory fitness and muscular endurance. It requires relatively good balance and coordination. It is necessary to learn the basics of skating including turning and stopping and to wear protective gear to avoid possible injury.",
-    "You can skate at a comfortable pace for 30 minutes straight. If you want a cardio challenge, do interval skating â€“ speed skate two minutes of every five minutes, using the remaining three minutes to recover. A 150 lb person will typically burn about 175 calories in 30 minutes skating at a comfortable pace, similar to brisk walking."
+    "You can skate at a comfortable pace for 30 minutes straight. If you want a cardio challenge, do interval skating — speed skate two minutes of every five minutes, using the remaining three minutes to recover. A 150 lb person will typically burn about 175 calories in 30 minutes skating at a comfortable pace, similar to brisk walking."
   ],
   "category": "cardio"
 }

--- a/exercises/Split_Jerk/exercise.json
+++ b/exercises/Split_Jerk/exercise.json
@@ -16,7 +16,7 @@
   "instructions": [
     "Standing with the weight racked on the front of the shoulders, begin with the dip. With your feet directly under your hips, flex the knees without moving the hips backward.",
     "Go down only slightly, and reverse direction as powerfully as possible. Drive through the heels create as much speed and force as possible, and be sure to move your head out of the way as the bar leaves the shoulders. At this moment as the feet leave the floor, the feet must be placed into the receiving position as quickly as possible.",
-    "In the brief moment the feet are not actively driving against the platform, the athleteâ€™s effort to push the bar up will drive them down. The feet should be moved to a split stance, one foot forward, one foot back, with the knees partially bent. Receive the bar with the arms locked out overhead.",
+    "In the brief moment the feet are not actively driving against the platform, the athlete's effort to push the bar up will drive them down. The feet should be moved to a split stance, one foot forward, one foot back, with the knees partially bent. Receive the bar with the arms locked out overhead.",
     "Return to a standing position, bringing the feet together."
   ],
   "category": "olympic weightlifting"

--- a/exercises/Squat_Jerk/exercise.json
+++ b/exercises/Squat_Jerk/exercise.json
@@ -14,7 +14,7 @@
   ],
   "instructions": [
     "Standing with the weight racked on the front of the shoulders, begin with the dip. With your feet directly under your hips, flex the knees without moving the hips backward. Go down only slightly, and reverse direction as powerfully as possible. Drive through the heels create as much speed and force as possible, and be sure to move your head out of the way as the bar leaves the shoulders.",
-    "At this moment as the feet leave the floor, the feet must be placed into the receiving position as quickly as possible. In the brief moment the feet are not actively driving against the platform, the athleteâ€™s effort to push the bar up will drive them down. The feet should move forcefully to just outside the hips, turned out as necessary. Receive the bar with your body in a full squat and the arms fully extended overhead.",
+    "At this moment as the feet leave the floor, the feet must be placed into the receiving position as quickly as possible. In the brief moment the feet are not actively driving against the platform, the athlete's effort to push the bar up will drive them down. The feet should move forcefully to just outside the hips, turned out as necessary. Receive the bar with your body in a full squat and the arms fully extended overhead.",
     "Keeping the bar aligned over the front of the heels, your head and chest up, drive throught heels of the feet to move to a standing position. Carefully return the weight to floor."
   ],
   "category": "strength"

--- a/exercises/Stairmaster/exercise.json
+++ b/exercises/Stairmaster/exercise.json
@@ -8,7 +8,7 @@
   "secondaryMuscles": ["calves", "glutes", "hamstrings"],
   "instructions": [
     "To begin, step onto the stairmaster and select the desired option from the menu. You can choose a manual setting, or you can select a program to run. Typically, you can enter your age and weight to estimate the amount of calories burned during exercise.",
-    "Pump your legs up and down in an established rhythm, driving the pedals down but not all the way to the floor. It is recommended that you maintain your grip on the handles so that you donâ€™t fall. The handles can be used to monitor your heart rate to help you stay at an appropriate intensity.",
+    "Pump your legs up and down in an established rhythm, driving the pedals down but not all the way to the floor. It is recommended that you maintain your grip on the handles so that you don't fall. The handles can be used to monitor your heart rate to help you stay at an appropriate intensity.",
     "Stairmasters offer convenience, cardiovascular benefits, and usually have less impact than running outside. They are typically much harder than other cardio equipment. A 150 lb person will typically burn over 300 calories in 30 minutes, compared to about 175 calories walking."
   ],
   "category": "cardio"

--- a/exercises/Standing_Cable_Lift/exercise.json
+++ b/exercises/Standing_Cable_Lift/exercise.json
@@ -12,7 +12,7 @@
   ],
   "instructions": [
     "Connect a standard handle on a tower, and move the cable to the lowest pulley position.",
-    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately armâ€™s length away from the pulley, with the tension of the weight on the cable. Your outstretched arm should be aligned with the cable.",
+    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately arm's length away from the pulley, with the tension of the weight on the cable. Your outstretched arm should be aligned with the cable.",
     "With your feet positioned shoulder width apart, squat down and grab the handle with both hands. Your arms should still be fully extended.",
     "In one motion, pull the handle up and across your body until your arms are in a fully-extended position above your head.",
     "Keep your back straight and your arms close to your body as you pivot your back foot and straighten your legs to get a full range of motion.",

--- a/exercises/Standing_Cable_Wood_Chop/exercise.json
+++ b/exercises/Standing_Cable_Wood_Chop/exercise.json
@@ -8,7 +8,7 @@
   "secondaryMuscles": ["shoulders"],
   "instructions": [
     "Connect a standard handle to a tower, and move the cable to the highest pulley position.",
-    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately armâ€™s length away from the pulley, with the tension of the weight on the cable. Your outstretched arm should be aligned with the cable.",
+    "With your side to the cable, grab the handle with one hand and step away from the tower. You should be approximately arm's length away from the pulley, with the tension of the weight on the cable. Your outstretched arm should be aligned with the cable.",
     "With your feet positioned shoulder width apart, reach upward with your other hand and grab the handle with both hands. Your arms should still be fully extended.",
     "In one motion, pull the handle down and across your body to your front knee while rotating your torso.",
     "Keep your back and arms straight and core tight while you pivot your back foot and bend your knees to get a full range of motion.",

--- a/exercises/Step_Mill/exercise.json
+++ b/exercises/Step_Mill/exercise.json
@@ -7,7 +7,7 @@
   "primaryMuscles": ["quadriceps"],
   "secondaryMuscles": ["calves", "glutes", "hamstrings"],
   "instructions": [
-    "To begin, step onto the stepmill and select the desired option from the menu. You can choose a manual setting, or you can select a program to run. Typically, you can enter your age and weight to estimate the amount of calories burned during exercise. Use caution so that you donâ€™t trip as you climb the stairs. It is recommended that you maintain your grip on the handles so that you donâ€™t fall.",
+    "To begin, step onto the stepmill and select the desired option from the menu. You can choose a manual setting, or you can select a program to run. Typically, you can enter your age and weight to estimate the amount of calories burned during exercise. Use caution so that you don't trip as you climb the stairs. It is recommended that you maintain your grip on the handles so that you don't fall.",
     "Stepmills offer convenience, cardiovascular benefits, and usually have less impact than running outside while offering a similar rate of calories burned. They are typically much harder than other cardio equipment. A 150 lb person will typically burn over 300 calories in 30 minutes, compared to about 175 calories walking."
   ],
   "category": "cardio"

--- a/exercises/Walking,_Treadmill/exercise.json
+++ b/exercises/Walking,_Treadmill/exercise.json
@@ -14,7 +14,7 @@
   ],
   "instructions": [
     "To begin, step onto the treadmill and select the desired option from the menu. Most treadmills have a manual setting, or you can select a program to run. Typically, you can enter your age and weight to estimate the amount of calories burned during exercise. Elevation can be adjusted to change the intensity of the workout.",
-    "Treadmills offer convenience, cardiovascular benefits, and usually have less impact than walking outside. When walking, you should move at a moderate to fast pace, not a leisurely one. Being an activity of lower intensity, walking doesnâ€™t burn as many calories as some other activities, but still provides great benefit. A 150 lb person will burn about 175 calories walking 4 miles per hour for 30 minutes, compared to 450 calories running twice as fast. Maintain proper posture as you walk, and only hold onto the handles when necessary, such as when dismounting or checking your heart rate."
+    "Treadmills offer convenience, cardiovascular benefits, and usually have less impact than walking outside. When walking, you should move at a moderate to fast pace, not a leisurely one. Being an activity of lower intensity, walking doesn't burn as many calories as some other activities, but still provides great benefit. A 150 lb person will burn about 175 calories walking 4 miles per hour for 30 minutes, compared to 450 calories running twice as fast. Maintain proper posture as you walk, and only hold onto the handles when necessary, such as when dismounting or checking your heart rate."
   ],
   "category": "cardio"
 }

--- a/exercises/Weighted_Pull_Ups/exercise.json
+++ b/exercises/Weighted_Pull_Ups/exercise.json
@@ -13,7 +13,7 @@
   ],
   "instructions": [
     "Attach a weight to a dip belt and secure it around your waist. Grab the pull-up bar with the palms of your hands facing forward. For a medium grip, your hands should be spaced at shoulder width. Both arms should be extended in front of you holding the bar at the chosen grip.",
-    "Youâ€™ll want to bring your torso back about 30 degrees while creating a curvature in your lower back and sticking your chest out. This will be your starting position.",
+    "You'll want to bring your torso back about 30 degrees while creating a curvature in your lower back and sticking your chest out. This will be your starting position.",
     "Now, exhale and pull your torso up until your head is above your hands. Concentrate on squeezing yourshoulder blades back and down as you reach the top contracted position.",
     "After a brief moment at the top contracted position, inhale and slowly lower your torso back to the starting position with your arms extended and your lats fully stretched."
   ],


### PR DESCRIPTION
I found that a number of the exercises' instructions have characters that seem to have been wrongly decoded from their original UTF-8 meaning, using some other encoding, and then saved into the files. I've fixed all of the wrong characters I found but there could potentially be more.

I fixed them using iconv to convert the contents of the files from UTF-8 to Windows-1252 (which I guessed was the incorrectly used encoding at some point when the original data was collected) and then saved the correct characters back into the files, along with some manual changing.

Here is a better explanation of the issue https://stackoverflow.com/a/2477480